### PR TITLE
Stable htmlWidget id

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,14 @@ Package: inborutils
 Title: Collection of useful R utilities and snippets
 Version: 0.0.1
 Date: 2017-12-09
-Authors@R: c(person("Stijn", "Van Hoey", role = c("aut", "cre"),
+Authors@R: c(
+  person("Stijn", "Van Hoey", role = c("aut", "cre"),
     email = "stijnvanhoey@gmail.com",
     comment = "http://orcid.org/0000-0001-6413-3185"), 
-             person("Pieter", "Verschelde", role = c("aut")))
+  person("Pieter", "Verschelde", role = c("aut")),
+  person("Thierry", "Onkelinx", role = c("aut"),
+    email = "thierry.onkelinx@inbo.be",
+    comment = "http://orcid.org/0000-0001-8804-4216"))
 Description: While working on research projects, typical small functionalities are useful across these projects. Instead of copy-pasting these functions in all indidivual project repositories/folders, this package collects these functions for reuse by ourself and - if useful - others as well.
 Depends: R (>= 3.4.2)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: inborutils
 Title: Collection of useful R utilities and snippets
-Version: 0.0.0.9000
+Version: 0.0.1
+Date: 2017-12-09
 Authors@R: c(person("Stijn", "Van Hoey", role = c("aut", "cre"),
     email = "stijnvanhoey@gmail.com",
     comment = "http://orcid.org/0000-0001-6413-3185"), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     rmarkdown,
     testthat,
     ggplot2,
+    htmlwidgets,
     drat
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/vignettes/guess_projection.Rmd
+++ b/vignettes/guess_projection.Rmd
@@ -7,6 +7,7 @@ vignette: >
   %\VignetteIndexEntry{Vignette Title}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+  %\VignetteDepends{htmlwidgets}
 ---
 
 ```{r, echo=FALSE}
@@ -42,6 +43,12 @@ The `guess_projection` function requires as minimal inputs:
 3.  the latitude column name. 
 
 For example:
+
+```{r echo = FALSE}
+library(htmlwidgets)
+setWidgetIdSeed(20171209)
+```
+
 
 ```{r fig.width=7, message=FALSE}
 # my_dataframe has the columns "longitude" and "latitude"


### PR DESCRIPTION
Added a seed for htmlWidget so that they get a stable id. The old behaviour gave a different id for each run. Which results in unwanted changes when placing the rendered documentation under version control.