### PR TITLE
Fix warning behaviour with coercing errors

### DIFF
--- a/R/gbif_species_name_match.R
+++ b/R/gbif_species_name_match.R
@@ -52,7 +52,8 @@ gbif_species_name_match <- function(df, name_col,
 
     # matching the GBiF matching information to the sample_data
     df %>% rowwise() %>%
-        do_(interp(~ as.data.frame(name_backbone(name = .$x)),
+        do_(interp(~ as.data.frame(name_backbone(name = .$x), 
+                                   stringsAsFactors = FALSE),
                    x = as.name(name_col))) %>%
         select(gbif_terms) %>%
         bind_cols(df)


### PR DESCRIPTION
Fixes the warnings when running the name matching, by making sure the strings are not interpreted to factors. 

@DimEvil when merged, you have to reinstall inborutils, reload and check it out