### PR TITLE
Simplify build + pkgdown commands and keep history on gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-language: R
+language: r
 sudo: required
 cache: packages
-warnings_are_errors: true
 
 r_binary_packages:
  - rgdal
+
+r_github_packages:
+  - r-lib/pkgdown
 
 addons:
   apt:
@@ -15,21 +17,14 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install libgdal1-dev
   
-before_script:
-  - Rscript -e "install.packages('devtools')"
-  - Rscript -e "devtools::install_github('hadley/pkgdown')"
-
-script:
-  - R CMD build .
-  - R CMD check *tar.gz
-  - R CMD INSTALL --no-docs --no-help .
+after_success:
   - Rscript -e "pkgdown::build_site(preview = FALSE)"
 
 deploy:
   provider: pages
-  skip_cleanup: true
   local_dir: docs
-  github_token: "$GH_TOKEN"
+  skip_cleanup: true
+  keep_history: true
+  github_token: $GH_TOKEN
   on:
     branch: master
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: r
-sudo: required
 cache: packages
 
 r_binary_packages:
@@ -8,14 +7,9 @@ r_binary_packages:
 r_github_packages:
   - r-lib/pkgdown
 
-addons:
-  apt:
-    packages:
-      - libudunits2-dev
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install libgdal1-dev
+apt_packages:
+  - libudunits2-dev
+  - libgdal1-dev
   
 after_success:
   - Rscript -e "pkgdown::build_site(preview = FALSE)"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
   person("Damiano", "Oldoni", role = c("ctb"), email = "damiano.oldoni@inbo.be", comment = c(ORCID = "0000-0003-3445-7562")),
   person("Peter", "Desmet", role = c("ctb"), email = "peter.desmet@inbo.be", comment = c(ORCID = "0000-0002-8442-8025")))
 Description: While working on research projects, typical small functionalities are useful across these projects. Instead of copy-pasting these functions in all indidivual project repositories/folders, this package collects these functions for reuse by ourself and - if useful - others as well.
-Depends: R (>= 3.4.2)
+Depends: R (>= 3.4.0)
 Imports:
     assertable,
     assertthat,


### PR DESCRIPTION
- Use r_github_packages for installing devtools
- Don't specify R CMD build etc: is done by default for packages
- Keep history on gh-pages

Don't merge yet, will test on travis.

I will also try to simplify the `sudo apt-get`