### PR TITLE
pkgdown website updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: r
 cache: packages
 
-r_binary_packages:
- - rgdal
+r_packages:
+  - pkgdown
 
-r_github_packages:
-  - r-lib/pkgdown
+r_binary_packages:
+  - rgdal
 
 apt_packages:
   - libudunits2-dev
   - libgdal1-dev
-  
+
 after_success:
   - R CMD INSTALL . # Install the package to build vignettes
   - Rscript -e "pkgdown::build_site(preview = FALSE)"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: inborutils
 Title: Collection of Useful R Utilities
-Version: 0.1.0.9067
+Version: 0.1.0.9069
 Description: While working on research projects, typical small functionalities 
     are useful across these projects. Instead of copy-pasting these functions in 
     all indidivual project repositories/folders, this package collects these 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # inborutils package
 
+<!-- badges: start -->
 [![Travis-CI Build Status](https://travis-ci.org/inbo/inborutils.svg?branch=master)](https://travis-ci.org/inbo/inborutils) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/69u29qd7n8aeuasf?svg=true)](https://ci.appveyor.com/project/stijnvanhoey/inborutils)
+<!-- badges: end -->
 
 This `inborutils` package provides a collection of useful R utilities and snippets that we consider recyclable for multiple projects. The functions are either out of scope or just not mature enough to include as extensions to existing packages. 
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,8 @@ template:
   params:
     bootswatch: yeti
 
+url: https://inbo.github.io/inborutils
+
 reference:
   - title: "GIS utilities"
     desc: "Functions for working with GIS data and maps"


### PR DESCRIPTION
This should e.g. make that the link to `download_zenodo()` in [this](https://inbo.github.io/n2khab/reference/download_zenodo.html) pkgdown-site page of the `n2khab` package does not automatically point to (currently) https://rdrr.io/pkg/inborutils/man/download_zenodo.html but to https://inbo.github.io/inborutils/reference/download_zenodo.html

That `pkgdown` behaviour is documented [here](https://pkgdown.r-lib.org/articles/linking.html#across-packages).