### PR TITLE
plot_coordinates_on_map(), reproject_coordinates(): documentation references to topics

### DIFF
--- a/R/plot_coordinates_on_map.R
+++ b/R/plot_coordinates_on_map.R
@@ -9,12 +9,12 @@
 #' @param col_long,col_lat Column names or positions of the x (longitude) and y
 #'   (latitude) column. They are passed to \code{\link[tidyselect]{vars_pull}}.
 #'   These arguments are passed by expression and support
-#'   \code{\link[rlang]{quasiquotation}} (you can unquote column names or column
+#'   \code{\link{quasiquotation}} (you can unquote column names or column
 #'   positions).
 #' @param projection Projection string of class CRS-class (\code{sp} objects) or
 #'   crs-class (\code{sf} objects) defining the current projection.
 #' @param ... Additional arguments passed on to
-#'   \code{\link[leaflet]{addCircleMarkers}} to customize points.
+#'   \code{\link{addCircleMarkers}} to customize points.
 #'
 #' @return Leaflet map with coordinates added as dots.
 #'

--- a/R/plot_coordinates_on_map.R
+++ b/R/plot_coordinates_on_map.R
@@ -1,7 +1,7 @@
 #' Plot x/y coordinates on a map
 #'
 #' This function plots x/y coordinates from a data.frame on a (leaflet) map. The
-#' coordinates are first converted to GWS84 in order to map them correctly on
+#' coordinates are first converted to WGS84 in order to map them correctly on
 #' the leaflet map (@seealso [reproject_coordinates()]). To do this, the
 #' original Coordinate Reference System (CRS) is asked.
 #'

--- a/R/reproject_coordinates.R
+++ b/R/reproject_coordinates.R
@@ -9,8 +9,8 @@
 #' @param col_long,col_lat Column names or positions of the x (longitude) and y
 #'   (latitude) column. They are passed to \code{\link[tidyselect]{vars_pull}}.
 #'   These arguments are passed by expression and support
-#'   \code{\link[rlang]{quasiquotation}} (you can unquote column names or column
-#'   positions).
+#'   \code{\link{quasiquotation}}
+#'   (you can unquote column names or column positions).
 #' @param crs_input Projection string of class CRS-class (\code{sp} compatible)
 #'   or crs-class (\code{sf} compatible) defining the current projection.
 #' @param crs_output Projection string of class CRS-class (\code{sp} compatible)

--- a/inborutils.Rproj
+++ b/inborutils.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/man/plot_coordinates_on_map.Rd
+++ b/man/plot_coordinates_on_map.Rd
@@ -26,7 +26,7 @@ Leaflet map with coordinates added as dots.
 }
 \description{
 This function plots x/y coordinates from a data.frame on a (leaflet) map. The
-coordinates are first converted to GWS84 in order to map them correctly on
+coordinates are first converted to WGS84 in order to map them correctly on
 the leaflet map (@seealso \code{\link[=reproject_coordinates]{reproject_coordinates()}}). To do this, the
 original Coordinate Reference System (CRS) is asked.
 }

--- a/man/plot_coordinates_on_map.Rd
+++ b/man/plot_coordinates_on_map.Rd
@@ -12,14 +12,14 @@ plot_coordinates_on_map(df, col_long, col_lat, projection, ...)
 \item{col_long, col_lat}{Column names or positions of the x (longitude) and y
 (latitude) column. They are passed to \code{\link[tidyselect]{vars_pull}}.
 These arguments are passed by expression and support
-\code{\link[rlang]{quasiquotation}} (you can unquote column names or column
+\code{\link{quasiquotation}} (you can unquote column names or column
 positions).}
 
 \item{projection}{Projection string of class CRS-class (\code{sp} objects) or
 crs-class (\code{sf} objects) defining the current projection.}
 
 \item{...}{Additional arguments passed on to
-\code{\link[leaflet]{addCircleMarkers}} to customize points.}
+\code{\link{addCircleMarkers}} to customize points.}
 }
 \value{
 Leaflet map with coordinates added as dots.

--- a/man/reproject_coordinates.Rd
+++ b/man/reproject_coordinates.Rd
@@ -12,8 +12,8 @@ reproject_coordinates(df, col_long, col_lat, crs_input, crs_output)
 \item{col_long, col_lat}{Column names or positions of the x (longitude) and y
 (latitude) column. They are passed to \code{\link[tidyselect]{vars_pull}}.
 These arguments are passed by expression and support
-\code{\link[rlang]{quasiquotation}} (you can unquote column names or column
-positions).}
+\code{\link{quasiquotation}}
+(you can unquote column names or column positions).}
 
 \item{crs_input}{Projection string of class CRS-class (\code{sp} compatible)
 or crs-class (\code{sf} compatible) defining the current projection.}


### PR DESCRIPTION
With a Windows user, some warnings were noticed when installing help indices during package installation:

```r
*** installing help indices
  converting help for package 'inborutils'
    finding HTML links ... done
    append_to_sqlite                        html  
    connect_inbo_dbase                      html  
    coordinate_example                      html  
    csv_to_sqlite                           html  
    dbDisconnect-OdbcConnection-method      html  
    finding level-2 HTML links ... done

    df_factors_to_char                      html  
    download_knmi_data_hour                 html  
    download_zenodo                         html  
    florabank_observations                  html  
    florabank_taxon_ifbl_year               html  
    florabank_traits                        html  
    gbif_species_name_match                 html  
    get_name_gbif                           html  
    guess_projection                        html  
    inborutils-package                      html  
    inboveg_classification                  html  
    inboveg_header                          html  
    inboveg_qualifiers                      html  
    inboveg_recordings                      html  
    inboveg_survey                          html  
    mow_header_split                        html  
    on_connection_opened                    html  
    plot_coordinates_on_map                 html  
Rd warning: C:/Users/xxxx/AppData/Local/Temp/RtmpAjgKnw/R.INSTALL305072c42ab2/inborutils/man/plot_coordinates_on_map.Rd:15: file link 'quasiquotation' in package 'rlang' does not exist and so has been treated as a topic
Rd warning: C:/Users/xxxx/AppData/Local/Temp/RtmpAjgKnw/R.INSTALL305072c42ab2/inborutils/man/plot_coordinates_on_map.Rd:22: file link 'addCircleMarkers' in package 'leaflet' does not exist and so has been treated as a topic
    plot_label_splitter                     html  
    rain_knmi_2012                          html  
    read_kmi_data                           html  
    read_kml_file                           html  
    read_knmi_data                          html  
    read_mow_data                           html  
    reproject_coordinates                   html  
Rd warning: C:/Users/xxxx/AppData/Local/Temp/RtmpAjgKnw/R.INSTALL305072c42ab2/inborutils/man/reproject_coordinates.Rd:15: file link 'quasiquotation' in package 'rlang' does not exist and so has been treated as a topic
    species_example                         html  
    vif                                     html  
```

Note, these complaints do not happen in Linux, nor does `R CMD check` complain.

The reason is explained [here](https://cran.r-project.org/doc/manuals/R-exts.html#Cross_002dreferences). The warnings have to do with the distinction between files and topics. It is recommended to not explicitly refer to package names, which I implemented here. An alternative approach is to explicitly name the actual file (e.g. `\code{\link[rlang:nse-force]{quasiquotation}}`) - however its name may later be changed by the package developer.

Beside that, a typo was fixed and RStudio's package check has been configured to always begin with updating the Rd files.
