### PR TITLE
human_filesize(): avoid note on floor() arguments at pkg installation time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,4 +63,4 @@ LazyData: true
 Encoding: UTF-8
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/download_zenodo.R
+++ b/R/download_zenodo.R
@@ -195,7 +195,7 @@ human_filesize <- function(x) {
   assert_that(all(x %% 1 == 0 & x >= 0))
   magnitude <-
     log(x, base = 1024) %>%
-    floor() %>%
+    floor %>%
     pmin(8)
   unit <- factor(magnitude,
                  levels = 0:8,

--- a/man/coordinate_example.Rd
+++ b/man/coordinate_example.Rd
@@ -4,12 +4,14 @@
 \name{coordinate_example}
 \alias{coordinate_example}
 \title{Example data.frame with coorindates}
-\format{A data frame with 52 rows and 3 variables:
+\format{
+A data frame with 52 rows and 3 variables:
 \itemize{
 \item{id: resource identifier}
 \item{latitude: Latitude of the coordinates}
 \item{longitude: Longitude of the coordinates}
-}}
+}
+}
 \usage{
 coordinate_example
 }

--- a/man/rain_knmi_2012.Rd
+++ b/man/rain_knmi_2012.Rd
@@ -4,7 +4,8 @@
 \name{rain_knmi_2012}
 \alias{rain_knmi_2012}
 \title{Example data.frame with KNMI downloaded data}
-\format{A data frame with 1536 rows and 9 variables:
+\format{
+A data frame with 1536 rows and 9 variables:
 \itemize{
 \item{value: measured value}
 \item{datetime: datetime of the measurement}
@@ -15,7 +16,8 @@
 \item{location_name: station name}
 \item{source_filename: filename from which the data was read}
 \item{quality_code: empty string as KNMI does not provide this}
-}}
+}
+}
 \usage{
 rain_knmi_2012
 }

--- a/man/species_example.Rd
+++ b/man/species_example.Rd
@@ -4,12 +4,14 @@
 \name{species_example}
 \alias{species_example}
 \title{Example data.frame with species name column}
-\format{A data frame with 3 rows and 3 variables
+\format{
+A data frame with 3 rows and 3 variables
 \itemize{
 \item {speciesName: name of the species}
 \item {kingdom: kingdom to which the species belongs}
 \item {euConcernStatus: level of concern according to EU directives}
-}}
+}
+}
 \usage{
 species_example
 }


### PR DESCRIPTION
Apparently, `... %>% floor() %>% ...` in the code of `human_filesize()` causes the annoying below note when installing the package - even though it is the recommended [tidyverse-styled way](https://style.tidyverse.org/pipes.html#no-arguments). Problem seems to be restricted to `floor()` here, doesn't occur with other such existing cases in the package.

```
* installing to library ‘/home/floris/lib/R/library’
* installing *source* package ‘inborutils’ ...
** using staged installation
** R
** data
*** moving datasets to lazyload DB
** inst
** byte-compile and prepare package for lazy loading

Note: wrong number of arguments to 'floor' at download_zenodo.R:196 

** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (inborutils)
```

Hence, I opt for the [magrittr approach](https://magrittr.tidyverse.org/#basic-piping) to drop argument-less `()` in pipes here - it effectively solves the note. Another effective solution was using `floor(.)`, but that resulted in a note on undeclared global variable `'.'`' in R CMD check. Though that can be solved too, it found it too inconvenient.

Meanwhile, applying documentation updates from `roxygen 7.1.0`.