### PR TITLE
[WIP] Fix locally failing tests (#74)

### DIFF
--- a/R/reproject_coordinates.R
+++ b/R/reproject_coordinates.R
@@ -35,8 +35,8 @@
 #' reproject_coordinates(data_pts, col_long = "lon", col_lat = "lat",
 #'   crs_input = sp_crs1, crs_output = sp_crs2)
 #' # crs-class (use sf package)
-#' sf_crs1 <- st_crs("+init=epsg:4269")
-#' sf_crs2 <- st_crs("+init=epsg:3857")
+#' sf_crs1 <- st_crs(4269)
+#' sf_crs2 <- st_crs(3857)
 #' reproject_coordinates(data_pts, col_long = "lon", col_lat = "lat",
 #'   crs_input = sf_crs1, crs_output = sf_crs2)
 #' # input projection is CRS-class (sp) and output projection crs-class (sf)

--- a/R/reproject_coordinates.R
+++ b/R/reproject_coordinates.R
@@ -131,7 +131,7 @@ reproject_coordinates <- function(df, col_long, col_lat,
   if (class(crs_output) == "CRS") {
     df[c(col_long, col_lat)] <- as.data.frame(df_reproj)[c(col_long, col_lat)]
   } else {
-    df[c(col_long, col_lat)] <- st_coordinates(df_reproj)
+    df[c(col_long, col_lat)] <- as.data.frame(st_coordinates(df_reproj))
   }
   return(df)
 }

--- a/tests/testthat/test-reproject_coordinates.R
+++ b/tests/testthat/test-reproject_coordinates.R
@@ -142,7 +142,7 @@ testthat::test_that("Same CRS input and output", {
 
 testthat::test_that(paste("input and output projections are both CRS-class",
                            "(sp points)"), {
-  expect_equal(data_out_sp_sp, read_reproj_df_sp)
+  expect_equal(as.data.frame(data_out_sp_sp), as.data.frame(read_reproj_df_sp))
 })
 
 testthat::test_that(paste("input projections of CRS-class (sp points),",

--- a/tests/testthat/test-reproject_coordinates.R
+++ b/tests/testthat/test-reproject_coordinates.R
@@ -11,9 +11,9 @@ library(readr)
 # )
 data_pts  <- read_tsv("./data_test_project_coordinate/data_pts_input.tsv")
 sp_crs1 <- CRS("+init=epsg:4269")
-sf_crs1 <- st_crs("+init=epsg:4269")
+sf_crs1 <- st_crs(4269)
 sp_crs2 <- CRS("+init=epsg:3857")
-sf_crs2 <- st_crs("+init=epsg:3857")
+sf_crs2 <- st_crs(3857)
 
 data_out_sp_sp <- reproject_coordinates(data_pts, col_long = lon, col_lat = lat,
                                         crs_input = sp_crs1,

--- a/tests/testthat/test-reproject_coordinates.R
+++ b/tests/testthat/test-reproject_coordinates.R
@@ -140,20 +140,20 @@ testthat::test_that("Same CRS input and output", {
 
 testthat::test_that(paste("input and output projections are both CRS-class",
                            "(sp points)"), {
-  expect_equal(as.data.frame(data_out_sp_sp), as.data.frame(read_reproj_df_sp), tolerance = 0.05)
+  expect_equal(data_out_sp_sp, read_reproj_df_sp)
 })
 
 testthat::test_that(paste("input projections of CRS-class (sp points),",
                           "output of crs-class (sf points)"), {
-  expect_equal(data_out_sp_sf, read_reproj_df_sf)
+  expect_equal(as.data.frame(data_out_sp_sf), as.data.frame(read_reproj_df_sf))
 })
 
 testthat::test_that(paste("input projections of crs-class (sf points),",
                           "output of CRS-class (sp points)"), {
-  expect_equal(as.data.frame(data_out_sf_sp), as.data.frame(read_reproj_df_sp), tolerance = 0.05)
+  expect_equal(as.data.frame(data_out_sf_sp), as.data.frame(read_reproj_df_sp))
 })
 
 testthat::test_that(paste("input and output projections are both crs-class",
                           "(sf points)"), {
-  expect_equal(data_out_sf_sf, read_reproj_df_sf)
+  expect_equal(as.data.frame(data_out_sf_sf), as.data.frame(read_reproj_df_sf))
 })

--- a/tests/testthat/test-reproject_coordinates.R
+++ b/tests/testthat/test-reproject_coordinates.R
@@ -10,9 +10,11 @@ library(readr)
 #   stringsAsFactors = FALSE
 # )
 data_pts  <- read_tsv("./data_test_project_coordinate/data_pts_input.tsv")
-sp_crs1 <- CRS("+init=epsg:4269")
+# epsg 4269
+sp_crs1 <- CRS("+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs")
 sf_crs1 <- st_crs(4269)
-sp_crs2 <- CRS("+init=epsg:3857")
+# epsg 3857
+sp_crs2 <- CRS("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
 sf_crs2 <- st_crs(3857)
 
 data_out_sp_sp <- reproject_coordinates(data_pts, col_long = lon, col_lat = lat,

--- a/tests/testthat/test-reproject_coordinates.R
+++ b/tests/testthat/test-reproject_coordinates.R
@@ -140,7 +140,7 @@ testthat::test_that("Same CRS input and output", {
 
 testthat::test_that(paste("input and output projections are both CRS-class",
                            "(sp points)"), {
-  expect_equal(data_out_sp_sp, read_reproj_df_sp)
+  expect_equal(as.data.frame(data_out_sp_sp), as.data.frame(read_reproj_df_sp), tolerance = 0.05)
 })
 
 testthat::test_that(paste("input projections of CRS-class (sp points),",
@@ -150,7 +150,7 @@ testthat::test_that(paste("input projections of CRS-class (sp points),",
 
 testthat::test_that(paste("input projections of crs-class (sf points),",
                           "output of CRS-class (sp points)"), {
-  expect_equal(data_out_sf_sp, read_reproj_df_sp)
+  expect_equal(as.data.frame(data_out_sf_sp), as.data.frame(read_reproj_df_sp), tolerance = 0.05)
 })
 
 testthat::test_that(paste("input and output projections are both crs-class",


### PR DESCRIPTION
I'm trying to fix the errors described in issue #74.

This is a work in progress, I've been able two solve two of the 4 issues. It was a simple precision issue (floating point values almost equal, so I just added some tolerance to the tests).

It's a bit more difficult for the two other failing tests, so I'm not against a second pair of eyes. More specifically, the first failing (the other looks VERY similar) test is:  

> test-reproject_coordinates.R:148: failure: input projections of CRS-class (sp points), output of crs-class (sf points)
`data_out_sp_sf` not equal to `read_reproj_df_sf`.
Incompatible type for column `lat`: x matrix, y numeric
Incompatible type for column `lon`: x matrix, y numeric

I inspected the variables, and it seems because the output of `reproject_coordinates()` is now more "rich" than expected:

reprojected value:

```
Browse[1]> str(data_out_sp_sf)
tibble [2 × 3] (S3: spec_tbl_df/tbl_df/tbl/data.frame)
 $ id : num [1:2] 1 2
 $ lat: num [1:2, 1:2] 565946 426308 6662134 6580588
  ..- attr(*, "dimnames")=List of 2
  .. ..$ : chr [1:2] "1" "2"
  .. ..$ : chr [1:2] "X" "Y"
 $ lon: num [1:2, 1:2] 565946 426308 6662134 6580588
  ..- attr(*, "dimnames")=List of 2
  .. ..$ : chr [1:2] "1" "2"
  .. ..$ : chr [1:2] "X" "Y"
 - attr(*, "spec")=
  .. cols(
  ..   id = col_double(),
  ..   lat = col_double(),
  ..   lon = col_double()
  .. )
```

and expected value:

```
Browse[1]> str(read_reproj_df_sf)
tibble [2 × 3] (S3: spec_tbl_df/tbl_df/tbl/data.frame)
 $ id : num [1:2] 1 2
 $ lat: num [1:2] 6662134 6580588
 $ lon: num [1:2] 565946 426308
 - attr(*, "spec")=
  .. cols(
  ..   id = col_double(),
  ..   lat = col_double(),
  ..   lon = col_double()
  .. )
```


