### PR TITLE
.travis.yml: ligdal-dev instead of libgdal1-dev *

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ r_packages:
 
 apt_packages:
   - libudunits2-dev
-  - libgdal1-dev
+  - libgdal-dev
 
 after_success:
   - R CMD INSTALL . # Install the package to build vignettes


### PR DESCRIPTION
_`libgdal1-dev`_ on Xenial is a 'transitional' package with as its only dependency `ligdal-dev`. The latter will be the one, needed on Bionic and Focal. So this should work already.

This commit was done in the context of discussion in #89.