### PR TITLE
Add setup_codingclub_session to page Reference page online

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -34,6 +34,10 @@ reference:
     contents:
       - connect_inbo_dbase
       - has_concept("inboveg")
+  - title: "INBO coding club utilities"
+    desc: "Download data and scripts of an INBO coding club session"
+    contents:
+      - setup_codingclub_session
   - title: "Florabank data interaction"
     desc: "Functions to read data from Florabank database"
     contents:


### PR DESCRIPTION
This small PR aims to add the documentation of `setup_codingclub_session()` to the [Reference page online](https://inbo.github.io/inborutils/reference/index.html).
It's a very small PR, but quite urgent as we would like to use it in next coding club within two days and referring to it in a coding club reminder email this evening.
Thanks.