### PR TITLE
Csv to sqlite issue42

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: inborutils
 Title: Collection of Useful R Utilities
-Version: 0.1.2
+Version: 0.1.3
 Description: While working on research projects, typical small functionalities 
     are useful across these projects. Instead of copy-pasting these functions in 
     all indidivual project repositories/folders, this package collects these 

--- a/R/csv_to_sqlite.R
+++ b/R/csv_to_sqlite.R
@@ -83,15 +83,18 @@ csv_to_sqlite <- function(csv_file, sqlite_file, table_name,
     dbWriteTable(con, table_name, df, overwrite = TRUE)
 
     # readr chunk functionality
+
     read_delim_chunked(
       csv_file,
       callback = append_to_sqlite(con = con, table_name = table_name,
                                   date_cols = date_cols,
                                   datetime_cols = datetime_cols),
       delim = delim,
-      skip = pre_process_size, chunk_size = chunk_size,
+      skip = pre_process_size + 1,
+      chunk_size = chunk_size,
       progress = show_progress_bar,
-      col_names = colnames(df), ...)
+      col_names = names(attr(df, "spec")$cols),
+      ...)
     dbDisconnect(con)
 }
 

--- a/tests/testthat/test-csv_to_sqlite.R
+++ b/tests/testthat/test-csv_to_sqlite.R
@@ -1,0 +1,55 @@
+test_that("csv to sqlite works", {
+  library(dplyr)
+  library(readr)
+  library(glue)
+  library(odbc)
+  library(RSQLite)
+
+  cols_subset <- cols_only(
+    mpg = col_double(),
+    hp = col_double(),
+    gear = col_double()
+  )
+
+  mtcars <- read_csv(readr_example("mtcars.csv"))
+  temp_dir <- tempdir()
+  oldwd <- getwd()
+  setwd(temp_dir)
+  mtcars_csv <- "mtcars.csv"
+  write_csv(mtcars, mtcars_csv)
+  mtcars_sqlite_cols_only <- "./mtcars_sqlite_cols_only.sqlite"
+  table_name <- "mtcars"
+
+  csv_to_sqlite(csv_file = mtcars_csv,
+                sqlite_file = mtcars_sqlite_cols_only,
+                table_name = table_name,
+                pre_process_size = 10,
+                chunk_size = 5,
+                delim = ",",
+                col_types = cols_subset
+  )
+
+  mtcars_sqlite_cols_only <- dbConnect(SQLite(), dbname = mtcars_sqlite_cols_only)
+
+  ## Get values
+  query <- glue_sql(
+    "SELECT * FROM {table}",
+    table = table_name,
+    .con = mtcars_sqlite_cols_only
+  )
+
+  mtcars_cols_only <- dbGetQuery(mtcars_sqlite_cols_only, query)
+
+  dbDisconnect(mtcars_sqlite_cols_only)
+  # check original data
+  mtcars_original_cols_only <- mtcars %>%
+    select(mpg, hp, gear) %>%
+    as.data.frame()
+
+  expect_equal(
+    mtcars_cols_only,
+    mtcars_original_cols_only
+    )
+
+  setwd(oldwd)
+})


### PR DESCRIPTION
Fixes #42 and a bug unrelated to that issue (in the sqlite version, one row was duplicated compared to the csv version because when `col_names` is set to a character vector in `read_delim_chunk()`, it will consider the first row of the csv file as a data row instead of a header row).

I added a unit test based on the example provided in issue #42.

